### PR TITLE
Replace --json option with --output option for the build command

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -12,7 +12,7 @@ class BuildCommand extends TerraformCommand {
       .setName('build')
       .setDescription('build code used by terraform configuration (e.g. AWS Lambda, Google Functions)')
       .addOption('silent', 's', 'Runs the commands without console output', Boolean, false)
-      .addOption('json', 'j', 'Output only build result in json format', Boolean, false)
+      .addOption('output', 'o', 'Log only the command result in one of the following formats: json', String, '')
     ;
   }
 
@@ -20,12 +20,19 @@ class BuildCommand extends TerraformCommand {
    * @return {Promise}
    */
   run() {
+    const output = this.getOption('output');
+    const silent = this.getOption('silent');
+
+    if (output && !['json'].includes(output)) {
+      return Promise.reject(new Error(`The '${output}' output format is not supported for this command.`));
+    }
+
     const config = this.getConfigTree();
     const distributor = new Distributor(config, {
       worker: 'build-worker.js',
       env: {
-        silent: this.getOption('silent'),
-        json: this.getOption('json')
+        silent: silent,
+        output: output
       }
     });
 

--- a/src/helpers/build-worker.js
+++ b/src/helpers/build-worker.js
@@ -75,13 +75,13 @@ function getComponentBuildTask(config) {
         child.stdout.on('data', data => {
           stdout.push(data);
 
-          if (process.env.json === 'false' && process.env.silent === 'false') {
+          if (!process.env.output && process.env.silent === 'false') {
             logger.raw(out(name, data));
           }
         });
 
         child.stderr.on('data', data => {
-          if (process.env.json === 'false' && process.env.silent === 'false') {
+          if (!process.env.output && process.env.silent === 'false') {
             logger.error(out(name, data));
           }
         });
@@ -89,8 +89,11 @@ function getComponentBuildTask(config) {
         return promise.then(() => Buffer.concat(stdout));
       })
     ).then(() => {
-      if (process.env.json === 'true') {
-        console.log(JSON.stringify({ message: 'Build successfully finished.' }, null, 2));
+      switch (process.env.output) {
+        case 'json': {
+          console.log(JSON.stringify({ message: 'Build successfully finished.' }, null, 2));
+          break;
+        }
       }
 
       resolve();

--- a/src/templates/help/metadata.json
+++ b/src/templates/help/metadata.json
@@ -63,10 +63,10 @@
           "defaultValue": false
         },
         {
-          "name": "json",
-          "shortcut": "j",
-          "description": "Output only build result in json format",
-          "defaultValue": false
+          "name": "output",
+          "shortcut": "o",
+          "description": "Log only result in one of the specified formats: json",
+          "defaultValue": ""
         },
         {
           "name": "include",


### PR DESCRIPTION
Console log:
```
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o json
{
  "message": "Build successfully finished."
}
{
  "message": "Build successfully finished."
}
{
  "message": "Build successfully finished."
}
✅ Done
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o yml
❌ The 'yml' output format is not supported for this command.
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ 
```