### PR TITLE
Fix and improve build command

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -12,7 +12,7 @@ class BuildCommand extends TerraformCommand {
       .setName('build')
       .setDescription('build code used by terraform configuration (e.g. AWS Lambda, Google Functions)')
       .addOption('silent', 's', 'Runs the commands without console output', Boolean, false)
-      .addOption('output', 'o', 'Log only the command result in one of the following formats: json', String, '')
+      .addOption('output', 'o', 'Log only the command result in one of the following formats: json, text', String, '')
     ;
   }
 
@@ -23,7 +23,7 @@ class BuildCommand extends TerraformCommand {
     const output = this.getOption('output');
     const silent = this.getOption('silent');
 
-    if (output && !['json'].includes(output)) {
+    if (output && !['json', 'text'].includes(output)) {
       return Promise.reject(new Error(`The '${output}' output format is not supported for this command.`));
     }
 

--- a/src/helpers/build-worker.js
+++ b/src/helpers/build-worker.js
@@ -89,22 +89,35 @@ function getComponentBuildTask(config) {
         return promise.then(() => Buffer.concat(stdout));
       })
     ).then(() => {
-      switch (process.env.output) {
-        case 'json': {
-          console.log(JSON.stringify({ message: `Build successfully finished for [${name}].` }, null, 2));
-          break;
-        }
-      }
+      printOutput(`Build successfully finished for [${name}].`, true);
 
       resolve();
     }).catch(err => {
-      if (process.env.json === 'true') {
-        console.log(JSON.stringify({ message: `Build failed for [${name}].` }, null, 2));
-      }
+      printOutput(`Build failed for [${name}].`, false);
 
       reject(err);
     });
   });
+}
+
+/**
+ * @param {String} message
+ * @param {Boolean} isSuccess
+ */
+function printOutput(message, isSuccess) {
+  switch (process.env.output) {
+    case 'json': {
+      logger.log(JSON.stringify({ message: message }, null, 2));
+      break;
+    }
+    case 'text': {
+      if (isSuccess) {
+        logger.info(message);
+      } else {
+        logger.error(message);
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Fixed unhandled promise rejection and improved --output option for the build command

Console log:
```
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o json
{
  "message": "Build successfully finished for [get-messages]."
}
{
  "message": "Build successfully finished for [websocket-bucket]."
}
{
  "message": "Build successfully finished for [send-message]."
}
✅ Done
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o json
{
  "message": "Build successfully finished for [get-messages]."
}
{
  "message": "Build failed for [websocket-bucket]."
}
❌ Worker error: "`cat wrong_file` failed with code 1"
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o text
✅ Build successfully finished for [get-messages].
✅ Build successfully finished for [websocket-bucket].
✅ Build successfully finished for [send-message].
✅ Done
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ thub build -o text
✅ Build successfully finished for [get-messages].
❌ Build failed for [websocket-bucket].
❌ Worker error: "`cat wrong_file` failed with code 1"
dory@dor-Lenovo-G50-70:~/projects/websockets-test$ 
```