### PR TITLE
fix `terrahub output` command for in-terraform use

### DIFF
--- a/src/helpers/distributor.js
+++ b/src/helpers/distributor.js
@@ -172,7 +172,13 @@ class Distributor {
     if (outputs[0].env.format === 'json') {
       const result = {};
 
-      outputs.forEach(it => result[it.component] = JSON.parse((new Buffer(it.stdout)).toString()));
+      outputs.forEach(it => {
+        let stdout = (new Buffer(it.stdout)).toString();
+        if (stdout[0] !== '{') {
+          stdout = stdout.slice(stdout.indexOf('{'));
+        }
+        result[it.component] = JSON.parse(stdout);
+      });
 
       logger.log(JSON.stringify(result));
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes usage of `terrahub output` command within `terraform` scripts
`Terraform` adds `o:` in the beginning of successful output. This PR fixes this problem.

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [ ] `terrahub output` in `terraform` script

## Checklist:
<!-- please check the boxes that matches your use case -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
