### PR TITLE
fix `git diff` doesn't throw an error in case of no changes

### DIFF
--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -223,7 +223,7 @@ class TerraformCommand extends AbstractCommand {
       this._handleGitDiffError(error);
     }
 
-    if (!stdout) {
+    if (!stdout || !stdout.toString().length) {
       throw new Error('There are no changes between commits, commit and working tree, etc.')
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #294 

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [x] `terrahub init --git-diff master...origin/master`

![image](https://user-images.githubusercontent.com/35968905/46540877-3baa6200-c8c3-11e8-9fab-317fc2495fe6.png)

## Checklist:
<!-- please check the boxes that matches your use case -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
