### PR TITLE
fix error message for exponential backoff

### DIFF
--- a/src/helpers/terraform.js
+++ b/src/helpers/terraform.js
@@ -203,7 +203,8 @@ class Terraform {
    * @private
    */
   _checkIgnoreError(error) {
-    return [/handshake timeout/, /connection reset by peer/, /failed to decode/, /EOF/].some(it => it.test(error.message));
+    return [/handshake timeout/, /connection reset by peer/,
+      /failed to decode/, /EOF/].some(it => it.test(error.message));
   }
 
   /**
@@ -296,7 +297,7 @@ class Terraform {
           ['add', 'change', 'destroy'].forEach((field, index) => metadata[field] = planCounter[index]);
         } else {
           ['add', 'change', 'destroy'].forEach((field) => metadata[field] = '0');
-        };
+        }
 
         this._output.metadata = metadata;
         const planPath = this._metadata.getPlanPath();
@@ -425,7 +426,7 @@ class Terraform {
       };
 
       return Promise.resolve(buffer);
-    })
+    });
   }
 
   /**

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -222,7 +222,7 @@ function exponentialBackoff(promiseFunction, options) {
       if (conditionFunction(error) && retries < maxRetries) {
         return setTimeoutPromise(1000 * Math.exp(retries++)).then(() => retry());
       } else {
-        error.Message += `${EOL}Failed after ${maxRetries} retries.`;
+        error.message += `${EOL}Failed after ${maxRetries} retries.`;
         return Promise.reject(error);
       }
     });


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes error message for exponential backoff doesn't contain number of retries made (`Failed after ${count} retries.` in the end of the error message)

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [x] `terrahub init` with no token specified. For test purpose in the code was added exponential backoff for errors, which contain `token` keyword in the error message

![image](https://user-images.githubusercontent.com/35968905/46716697-b8479280-cc6d-11e8-879a-639890097f1d.png)

## Checklist:
<!-- please check the boxes that matches your use case -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
