### PR TITLE
improve workflow execution of terrahub commands

### DIFF
--- a/src/commands/component.js
+++ b/src/commands/component.js
@@ -99,15 +99,15 @@ class ComponentCommand extends AbstractCommand {
 
     return terraform.workspaceList()
       .then(data => {
-        data.map(it => {
+        data.forEach(it => {
           if (it !== 'default') {
-            const outFile = path.join(directory, `.terrahub.${it}.yml`);
+            const outFile = path.join(directory, `.terrahub.${it}${this.getProjectFormat()}`);
             ConfigLoader.writeConfig({}, outFile);
           }
         });
-      }).catch(() => {
+
         return Promise.resolve();
-      })
+      }).catch(() => Promise.resolve())
       .then(() => {
         const existing = this._findExistingComponent();
 

--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -12,7 +12,7 @@ class OutputCommand extends TerraformCommand {
     this
       .setName('output')
       .setDescription('run `terraform output` across multiple terrahub components')
-      .addOption('format', 'o', 'Specify the output format (text or json)', String, 'text')
+      .addOption('format', 'o', 'Specify the output format (text or json)', String, '')
       .addOption('auto-approve', 'y', 'Auto approve terraform execution', Boolean, false)
     ;
   }
@@ -23,11 +23,11 @@ class OutputCommand extends TerraformCommand {
   run() {
     this._format = this.getOption('format');
 
-    if (!['text', 'json'].includes(this._format)) {
+    if (this._format && !['text', 'json'].includes(this._format)) {
       return Promise.reject(new Error(`The '${this._format}' output format is not supported for this command.`));
     }
 
-    return this._format === 'text' ? this.askQuestion() : this.performAction();
+    return !this._format ? this.askQuestion() : this.performAction();
   }
 
   /**

--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -23,7 +23,7 @@ class OutputCommand extends TerraformCommand {
   run() {
     this._format = this.getOption('format');
 
-    if (this._format && !['text', 'json'].includes(this._format)) {
+    if (!['text', 'json', ''].includes(this._format)) {
       return Promise.reject(new Error(`The '${this._format}' output format is not supported for this command.`));
     }
 

--- a/src/helpers/build-helper.js
+++ b/src/helpers/build-helper.js
@@ -65,7 +65,9 @@ class BuildHelper {
       ).then(() => {
         BuildHelper._printOutput(`Build successfully finished for [${name}].`, true);
 
-        resolve();
+        resolve({
+          action: 'build'
+        });
       }).catch(err => {
         BuildHelper._printOutput(`Build failed for [${name}].`, false);
 

--- a/src/helpers/distributor.js
+++ b/src/helpers/distributor.js
@@ -118,7 +118,7 @@ class Distributor {
       planDestroy: planDestroy
     };
 
-    this._output = [];
+    this._results = [];
     this._dependencyTable = this._buildDependencyTable(this._config, dependencyDirection);
     this.TERRAFORM_ACTIONS = actions;
 
@@ -132,7 +132,7 @@ class Distributor {
         }
 
         if (data.data) {
-          this._output.push(data.data);
+          this._results.push(data.data);
         }
 
         this._removeDependencies(data.hash);
@@ -152,9 +152,13 @@ class Distributor {
           if (this._error) {
             reject(this._error);
           } else {
-            this._handleOutput().then(message => {
-              resolve(message);
-            });
+            let message = 'Done';
+            if (format) {
+              this._handleOutput(format);
+              message = '';
+            }
+
+            resolve(message);
           }
         }
       });
@@ -163,34 +167,35 @@ class Distributor {
 
   /**
    * Prints the output data for the 'output' command
+   * @param {String} format
    * @return {*}
    * @private
    */
-  _handleOutput() {
-    const outputs = this._output.filter(it => it.action === 'output');
+  _handleOutput(format) {
+    const outputs = this._results.filter(it => it.action === 'output');
 
     if (!outputs.length) {
-      return Promise.resolve('Done');
+      return;
     }
 
-    if (outputs[0].env.format === 'json') {
-      const result = {};
+    switch (format) {
+      case 'json':
+        const result = {};
 
-      outputs.forEach(it => {
-        let stdout = (new Buffer(it.stdout)).toString();
-        if (stdout[0] !== '{') {
-          stdout = stdout.slice(stdout.indexOf('{'));
-        }
-        result[it.component] = JSON.parse(stdout);
-      });
+        outputs.forEach(it => {
+          let stdout = (Buffer.from(it.buffer)).toString('utf8');
+          if (stdout[0] !== '{') {
+            stdout = stdout.slice(stdout.indexOf('{'));
+          }
+          result[it.component] = JSON.parse(stdout);
+        });
 
-      logger.log(JSON.stringify(result));
+        logger.log(JSON.stringify(result));
+        break;
 
-      return Promise.resolve();
-    } else {
-      outputs.forEach(it => logger.raw(`[${it.component}] ${(new Buffer(it.stdout)).toString()}`));
-
-      return Promise.resolve('Done');
+      default:
+        outputs.forEach(it => logger.raw(`[${it.component}] ${(Buffer.from(it.stdout).toString('utf8'))}`));
+        break;
     }
   }
 
@@ -207,7 +212,9 @@ class Distributor {
     });
 
     this._dependencyTable = {};
-
+    if (err instanceof Array) {
+      err = err.map(it => Buffer.from(it).toString('utf8')).join(os.EOL);
+    }
     return (err.constructor === Error) ? err : new Error(`Worker error: ${JSON.stringify(err)}`);
   }
 }

--- a/src/helpers/distributor.js
+++ b/src/helpers/distributor.js
@@ -194,7 +194,7 @@ class Distributor {
         break;
 
       default:
-        outputs.forEach(it => logger.raw(`[${it.component}] ${(Buffer.from(it.stdout).toString('utf8'))}`));
+        outputs.forEach(it => logger.raw(`[${it.component}] ${(Buffer.from(it.buffer).toString('utf8'))}`));
         break;
     }
   }

--- a/src/helpers/terraform.js
+++ b/src/helpers/terraform.js
@@ -298,10 +298,10 @@ class Terraform {
 
     return exponentialBackoff(promiseFunction,
       { conditionFunction: this._checkIgnoreErrorPlan, maxRetries: config.retryCount })
-      .then(data => {
+      .then(buffer => {
         const metadata = {};
         const regex = /\s*Plan: ([0-9]+) to add, ([0-9]+) to change, ([0-9]+) to destroy\./;
-        const planData = data.toString().match(regex);
+        const planData = buffer.toString().match(regex);
 
         let skip = false;
         if (planData) {
@@ -322,7 +322,7 @@ class Terraform {
         }
 
         return Promise.resolve({
-          data: data,
+          buffer: buffer,
           skip: skip,
           metadata: metadata
         });

--- a/src/helpers/terraform.js
+++ b/src/helpers/terraform.js
@@ -240,9 +240,6 @@ class Terraform {
    * @return {Promise}
    */
   workspaceSelect() {
-
-    // console.log('workspace',config.env)
-    // console.log('test', this._tf)
     if (!this._isWorkspaceSupported) {
       return Promise.resolve();
     }

--- a/src/helpers/terraform.js
+++ b/src/helpers/terraform.js
@@ -240,6 +240,9 @@ class Terraform {
    * @return {Promise}
    */
   workspaceSelect() {
+
+    // console.log('workspace',config.env)
+    // console.log('test', this._tf)
     if (!this._isWorkspaceSupported) {
       return Promise.resolve();
     }

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -68,13 +68,14 @@ class Terrahub {
 
     if (!['init', 'workspaceSelect', 'plan', 'apply', 'output', 'destroy'].includes(this._action)) {
       return this._terraform[action]();
-    } else {
-      if (options && !options.aborted) {
-        return this._getTask();
-      } else {
-        return this._on('aborted');
-      }
     }
+
+    if (options && !options.aborted) {
+      return this._getTask();
+    } else {
+      return this._on('aborted');
+    }
+
 
     return (!['init', 'workspaceSelect', 'plan', 'apply', 'output', 'destroy'].includes(this._action) ?
       this._terraform[action]() : this._getTask());

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -127,7 +127,7 @@ class Terrahub {
 
             return (promise instanceof Promise ?
               promise :
-              Promise.resolve(promise)).then(() => Promise.resolve(res));
+              Promise.resolve()).then(() => Promise.resolve(res));
           };
 
         case '.sh':

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -72,10 +72,14 @@ class Terrahub {
         return this._terraform[action]();
       }
 
-      if (options && !options.aborted) {
-        return this._getTask();
+      if (options.aborted) {
+        return this._on('aborted', null, {})
+          .then(res => {
+            logger.warn(`Action '${this._action}' for '${this._config.name}' was aborted due to 'No changes. Infrastructure is up-to-date.'`);
+            return res;
+          });
       } else {
-        return this._on('aborted', null, {});
+        return this._getTask();
       }
     }).then(data => {
       data.action = this._action;

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -194,7 +194,7 @@ class Terrahub {
     const key = this._getKey();
     const url = `${Terrahub.METADATA_DOMAIN}/${key}`;
 
-    return this._putObject(url, data.buffer);
+    return this._putObject(url, data.buffer)
       .then(() => this._callParseLambda(key))
       .then(() => Promise.resolve(data));
   }

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -75,7 +75,7 @@ class Terrahub {
       if (options.aborted) {
         return this._on('aborted', null, {})
           .then(res => {
-            logger.warn(`Action '${this._action}' for '${this._config.name}' was aborted due to 'No changes. Infrastructure is up-to-date.'`);
+            logger.warn(`Action '${this._action}' for '${this._config.name}' was skipped due to 'No changes. Infrastructure is up-to-date.'`);
             return res;
           });
       } else {

--- a/src/helpers/terrahub.js
+++ b/src/helpers/terrahub.js
@@ -75,10 +75,6 @@ class Terrahub {
     } else {
       return this._on('aborted');
     }
-
-
-    return (!['init', 'workspaceSelect', 'plan', 'apply', 'output', 'destroy'].includes(this._action) ?
-      this._terraform[action]() : this._getTask());
   }
 
   /**

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -38,7 +38,11 @@ function uuid() {
  * @returns {*}
  */
 function promiseSeries(promises) {
-  return promises.reduce((prev, fn) => prev.then(fn), Promise.resolve());
+  return promises.reduce((prev, fn) => prev.then(data => {
+    const options = data ? { aborted: !!data.skip } : {};
+
+    return fn(options);
+  }), Promise.resolve());
 }
 
 /**
@@ -251,7 +255,7 @@ function setTimeoutPromise(timeout) {
  */
 function physicalCpuCount() {
   /**
-   * @param {String} command 
+   * @param {String} command
    * @return {String}
    */
   function exec(command) {
@@ -271,9 +275,9 @@ function physicalCpuCount() {
   } else if (platformCheck === 'windows') {
     const output = exec('WMIC CPU Get NumberOfCores');
     amount = output.split(EOL)
-      .map(function parse(line) { return parseInt(line) })
-      .filter(function numbers(value) { return !isNaN(value) })
-      .reduce(function add(sum, number) { return sum + number }, 0);
+      .map(function parse(line) { return parseInt(line); })
+      .filter(function numbers(value) { return !isNaN(value); })
+      .reduce(function add(sum, number) { return sum + number; }, 0);
   } else {
     const cores = cpus().filter(function (cpu, index) {
       const hasHyperthreading = cpu.model.includes('Intel');

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -35,14 +35,11 @@ function uuid() {
 
 /**
  * @param {Function[]} promises
+ * @param {Function} callback
  * @returns {*}
  */
-function promiseSeries(promises) {
-  return promises.reduce((prev, fn) => prev.then(data => {
-    const options = data ? { aborted: !!data.skip } : {};
-
-    return fn(options);
-  }), Promise.resolve());
+function promiseSeries(promises, callback = (prev, fn) => prev.then(fn)) {
+  return promises.reduce(callback, Promise.resolve());
 }
 
 /**

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -30,9 +30,10 @@ function getTasks(config) {
 /**
  * BladeRunner
  * @param {Object} config
+ * @param {Function} callback
  */
 function run(config) {
-  promiseSeries(getTasks(config)).then(lastResult => {
+  promiseSeries(getTasks(config), (prev, fn) => prev.then(data => fn(data ? { aborted: !!data.skip } : {}))).then(lastResult => {
     if (lastResult.action !== 'output') {
       delete lastResult.buffer;
     }

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -45,15 +45,16 @@ function run(config) {
         hash: config.hash
       });
       process.exit(0);
-    }).catch(error => {
-    process.send({
-      id: cluster.worker.id,
-      error: error.message || error,
-      isError: true,
-      hash: config.hash
+    })
+    .catch(error => {
+      process.send({
+        id: cluster.worker.id,
+        error: error.message || error,
+        isError: true,
+        hash: config.hash
+      });
+      process.exit(1);
     });
-    process.exit(1);
-  });
 }
 
 /**

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -33,11 +33,15 @@ function getTasks(config) {
  */
 function run(config) {
   promiseSeries(getTasks(config)).then(lastResult => {
+    if (lastResult.action !== 'output') {
+      delete lastResult.buffer;
+    }
+
     process.send({
       id: cluster.worker.id,
       data: lastResult,
       isError: false,
-      hash: config.hash
+      hash: config.hash,
     });
     process.exit(0);
   }).catch(error => {

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -30,22 +30,22 @@ function getTasks(config) {
 /**
  * BladeRunner
  * @param {Object} config
- * @param {Function} callback
  */
 function run(config) {
-  promiseSeries(getTasks(config), (prev, fn) => prev.then(data => fn(data ? { aborted: !!data.skip } : {}))).then(lastResult => {
-    if (lastResult.action !== 'output') {
-      delete lastResult.buffer;
-    }
+  promiseSeries(getTasks(config), (prev, fn) => prev.then(data => fn(data ? { aborted: !!data.skip } : {})))
+    .then(lastResult => {
+      if (lastResult.action !== 'output') {
+        delete lastResult.buffer;
+      }
 
-    process.send({
-      id: cluster.worker.id,
-      data: lastResult,
-      isError: false,
-      hash: config.hash
-    });
-    process.exit(0);
-  }).catch(error => {
+      process.send({
+        id: cluster.worker.id,
+        data: lastResult,
+        isError: false,
+        hash: config.hash
+      });
+      process.exit(0);
+    }).catch(error => {
     process.send({
       id: cluster.worker.id,
       error: error.message || error,

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -22,8 +22,8 @@ function getTasks(config) {
   const terrahub = new Terrahub(config);
 
   return getActions().map(action =>
-    () => (action !== 'build' ?
-      terrahub.getTask(action) : BuildHelper.getComponentBuildTask(config))
+    (options) => (action !== 'build' ?
+      terrahub.getTask(action, options) : BuildHelper.getComponentBuildTask(config))
   );
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #339 

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
After running following commands, if infrastructure is up to date, `apply/destroy` action will be skipped
- [x] `terrahub run -a -y`
- [x] `terrahub run -d -y`
- [x] `terrahub apply -y`
- [x] `terrahub destroy -y`
- [x] `terrahub init`
- [x] `terrahub workspace`
- [x] `terrahub plan`
- [x] `terrahub build` (w/ option format)
- [x] `terrahub output` (w/ option format)
- [x] ` terrahub refresh`

<img width="1144" alt="2018-11-16 16 06 08" src="https://user-images.githubusercontent.com/35734669/48626301-34926b80-e9ba-11e8-9e25-02064c38517c.png">

## Checklist:
<!-- please check the boxes that matches your use case -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
