### PR TITLE
Bugs fix

### DIFF
--- a/src/commands/component.js
+++ b/src/commands/component.js
@@ -222,7 +222,7 @@ class ComponentCommand extends AbstractCommand {
         });
 
         const templateName = this._configLoader.getDefaultFileName() + '.twig';
-        const specificConfigPath = path.join(path.dirname(templates.mapping), templateName);
+        const specificConfigPath = path.join(path.dirname(templates.config), templateName);
         const data = fse.existsSync(specificConfigPath) ? fse.readFileSync(specificConfigPath) : '';
 
         return renderTwig(

--- a/src/helpers/worker.js
+++ b/src/helpers/worker.js
@@ -99,9 +99,15 @@ function jitMiddleware(config) {
   const src = path.join(config.project.root, config.root);
   const regEx = /\.terrahub.*(json|yml|yaml)$/;
 
-  return fse.copy(src, tmpPath, { filter: (src, dest) => !regEx.test(src) })
-    .then(() => Promise.all(promises))
-    .then(() => Promise.resolve(cfg));
+  return fse.ensureDir(tmpPath)
+  .then(() => {
+    return fse.copy(src, tmpPath, { filter: (src, dest) => !regEx.test(src) })
+      .then(() => Promise.all(promises))
+      .then(() => Promise.resolve(cfg));
+  })
+  .catch(err => {
+    throw new Error(`${err}`);
+  });
 }
 
 /**


### PR DESCRIPTION
## Description
- Fixed issue 611
- Fixed issue 617

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# terrahub component -n test -d ./test
❌ TypeError: Path must be a string. Received undefined
    at assertPath (path.js:28:11)
    at Object.dirname (path.js:1346:5)
    at terraform.workspaceList.then.catch.then (/mnt/c/Terrahub/terrahub/src/commands/component.js:225:51)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# terrahub component -n test -d ./test
✅ Done
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# rm -rf ~/.terrahub/cache/
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# terrahub run -i main
Project: demo-terraform-automation-google
 └─ main
'terrahub run' action is executed for above list of components.
```

```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# rm -rf ~/.terrahub/cache/
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/demo-terraform-automation-google# terrahub run -i main
Project: demo-terraform-automation-google
 └─ main
'terrahub run' action is executed for above list of components.
💡 [main] terraform init -no-color -input=false .
[main]
Initializing the backend...
[main]
[main] Successfully configured the backend "local"! Terraform will automatically
use this backend unless the backend configuration changes.
[main]
Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
[main] - Downloading plugin for provider "google" (2.1.0)...
..
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
