### PR TITLE
fixed issue 767

### DIFF
--- a/src/helpers/jit-helper.js
+++ b/src/helpers/jit-helper.js
@@ -52,7 +52,6 @@ class JitHelper {
    */
   static _normalizeBackendLocalPath(config) {
     const { template } = config;
-    const { terraform: { backend: { local } } } = template;
     const { locals } = template;
     let localTfstatePath = path.resolve('/tmp/.terrahub/local_tfstate/', config.project.name);
 
@@ -64,14 +63,22 @@ class JitHelper {
         }
       });
     }
+    
+    const { terraform } = template;
 
-    if (local) {
-      Object.keys(local).filter(it => local[it]).map(() => {
-        const { path } = local;
-        if (path) {
-          local.path = path.replace(/\$\{local.component\["local"\]\}/g, localTfstatePath);
+    if (terraform) {
+      const { backend } = terraform;
+      if (backend) {
+        const { local } = backend;
+        if (local) {
+          Object.keys(local).filter(it => local[it]).map(() => {
+            const { path } = local;
+            if (path) {
+              local.path = path.replace(/\$\{local.component\["local"\]\}/g, localTfstatePath);
+            }
+          });
         }
-      });
+      }
     }
 
     return localTfstatePath;
@@ -85,7 +92,6 @@ class JitHelper {
    */
   static _normalizeBackendS3Key(config) {
     const { template } = config;
-    const { terraform: { backend: { s3 } } } = template;
     const { locals } = template;
     let remoteTfstatePath = path.join('terraform', config.project.name);
 
@@ -98,13 +104,21 @@ class JitHelper {
       });
     }
 
-    if (s3) {
-      Object.keys(s3).filter(it => s3[it]).map(() => {
-        const { key } = s3;
-        if (key) {
-          s3.key = key.replace(/\$\{local.component\["remote"\]\}/g, remoteTfstatePath);
+    
+    const { terraform } = template;
+    if (terraform) {
+      const { backend } = terraform;
+      if (backend) {
+        const { s3 } = backend;
+        if (s3) {
+          Object.keys(s3).filter(it => s3[it]).map(() => {
+            const { key } = s3;
+            if (key) {
+              s3.key = key.replace(/\$\{local.component\["remote"\]\}/g, remoteTfstatePath);
+            }
+          });
         }
-      });
+      }
     }
 
     return remoteTfstatePath;

--- a/src/helpers/wrappers/terraform.js
+++ b/src/helpers/wrappers/terraform.js
@@ -193,7 +193,13 @@ class Terraform {
     return this.run('state', ['pull', '-no-color']).then(result => {
       this._showLogs = true;
       const backupPath = this._metadata.getStateBackupPath();
-      const pullStateContent = JSON.parse(result.toString());
+      const stdout = result.toString();
+      const indexStart = stdout.indexOf('{');
+      const pullStateContent = JSON.parse(
+        stdout[0] !== '{'
+          ? stdout.substring(indexStart, stdout.length)
+          : stdout
+      );
 
       return fse.ensureFile(backupPath)
         .then(() => fse.writeJson(backupPath, pullStateContent))
@@ -430,13 +436,11 @@ class Terraform {
    * @private
    */
   _out(data) {
-    let str = data.toString();
-    
-    if (str.substr(0, 2) === "o:") {
-      str = str.substr(2, str.length - 2);
-    }
+    let stdout = data.toString();
+    const indexStart = stdout.indexOf('{');
+    stdout = stdout[0] !== '{' ? stdout.substring(indexStart, stdout.length) : stdout;
 
-    return `[${this.getName()}] ${str}`;
+    return `[${this.getName()}] ${stdout}`;
   }
 
   /**


### PR DESCRIPTION
## Description
- fixed issue #767 
- fixed `Worker error: "Unexpected token o in JSON at position 0"`

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terrahub-project# terrahub workspace -e test
💡 THUB_TOKEN is not provided.
Project: terrahub-project
 └─ terrahub-component-first
💡 'terrahub workspace' action is executed for above list of components.
💡 [terrahub-component-first] terraform init -no-color -force-copy -input=false .
[terrahub-component-first]
Initializing provider plugins...
[terrahub-component-first] - Checking for available provider plugins on https://releases.hashicorp.com...
[terrahub-component-first] - Downloading plugin for provider "aws" (2.13.0)...
[terrahub-component-first]
[terrahub-component-first] The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.13"

[terrahub-component-first] Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.
[terrahub-component-first]
If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
[terrahub-component-first] commands will detect it and remind you to do so if necessary.
💡 [terrahub-component-first] terraform workspace list
[terrahub-component-first] * default

💡 [terrahub-component-first] terraform workspace new test
[terrahub-component-first] Created and switched to workspace "test"!

[terrahub-component-first] You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
for this configuration.
✅ TerraHub environment 'test' was updated
```

```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone# terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

 <= module.landing-zone.data.external.landing_zone_output_file
      id:                  <computed>
      program.#:           "3"
      program.0:           "sh"
      program.1:           "/mnt/c/Terrahub/terraform-aws-landing-zone/.terraform/modules/81adf8bf67bf13c38387adc0d84a28f6/scripts/showoutput.sh"
      program.2:           "/mnt/c/Terrahub/terraform-aws-landing-zone/output.json"
      result.%:            <computed>

  + module.landing-zone.null_resource.landing_zone
      id:                  <computed>
      triggers.%:          "3"
      triggers.command:    "apply"
      triggers.components: "9958ef17264d045bf2ccef8e13ba636f"
      triggers.timestamp:  "2019-06-05T08:25:48Z"


Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.landing-zone.null_resource.landing_zone: Creating...
  triggers.%:          "" => "3"
  triggers.command:    "" => "apply"
  triggers.components: "" => "9958ef17264d045bf2ccef8e13ba636f"
  triggers.timestamp:  "" => "2019-06-05T08:26:47Z"
module.landing-zone.null_resource.landing_zone: Provisioning with 'local-exec'...
module.landing-zone.null_resource.landing_zone (local-exec): Executing: ["/bin/sh" "-c" "sh /mnt/c/Terrahub/terraform-aws-landing-zone/.terraform/modules/81adf8bf67bf13c38387adc0d84a28f6/scripts/apply.sh"]
module.landing-zone.null_resource.landing_zone: Still creating... (10s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (20s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (30s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (40s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (50s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (1m0s elapsed)
module.landing-zone.null_resource.landing_zone: Still creating... (1m10s elapsed)
module.landing-zone.null_resource.landing_zone (local-exec): Success
module.landing-zone.null_resource.landing_zone: Creation complete after 1m18s (ID: 3690298917342253970)
module.landing-zone.data.external.landing_zone_output_file: Refreshing state...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

landing_zone_pipeline_s3_bucket_arn = arn:aws:s3:::aws-landing-zone-configuration-eulian-us-east-1
landing_zone_pipeline_s3_bucket_bucket = aws-landing-zone-configuration-eulian-us-east-1
landing_zone_pipeline_s3_bucket_id = aws-landing-zone-configuration-eulian-us-east-1
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
