### PR TITLE
Fix: `ResponseError: index_not_found_exception`, deprecated `emitter.listenerCount` second argument, error when executing `terrahub configure` command

### DIFF
--- a/src/abstract-command.js
+++ b/src/abstract-command.js
@@ -269,7 +269,6 @@ class AbstractCommand {
 
   /**
    * @return {Promise}
-   * @protected
    */
   validateToken() {
     if (!config.token) {
@@ -277,13 +276,7 @@ class AbstractCommand {
     }
 
     return fetch.get('thub/account/retrieve')
-      .then((res) => {
-        if (res) {
-          this._tokenIsValid = true;
-        }
-
-        return Promise.resolve();
-      })
+      .then(res => Promise.resolve(!!res))
       .catch(err => {
         if (err instanceof AuthenticationException) {
           return this.onTokenMissingOrInvalid(config.token);

--- a/src/abstract-command.js
+++ b/src/abstract-command.js
@@ -24,7 +24,6 @@ class AbstractCommand {
     this._options = {};
     this._description = null;
     this._configLoader = new ConfigLoader();
-    this._tokenIsValid = false;
 
     this.configure();
     this.initialize();

--- a/src/helpers/api-helper.js
+++ b/src/helpers/api-helper.js
@@ -387,7 +387,7 @@ class ApiHelper extends events.EventEmitter {
    * @return {Promise}
    */
   sendLogToS3() {
-    if (this.canApiLogsBeSent()) {
+    if (this.canApiLogsBeSent() && this.apiLogginStart) {
       return fetch.post(`https://${api}.terrahub.io/v1/elasticsearch/logs/save/${this.runId}`)
         .catch(error => console.log(error));
     }

--- a/src/helpers/api-helper.js
+++ b/src/helpers/api-helper.js
@@ -26,7 +26,7 @@ class ApiHelper extends events.EventEmitter {
     }
 
     if (this.isWorkForLogger() && this.loggerIsFree) {
-      const counter = this.listenerCount('loggerWork', this);
+      const counter = this.listenerCount('loggerWork');
 
       if (counter < 2) {
         this.emit('loggerWork');
@@ -376,11 +376,11 @@ class ApiHelper extends events.EventEmitter {
   }
 
   /**
-   * @param {String} token
+   * @param {Boolean} token
    * @return {void}
    */
   setToken(token) {
-    this._tokenIsValid = !!token;
+    this._tokenIsValid = token;
   }
 
   /**

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -55,7 +55,9 @@ class TerraformCommand extends AbstractCommand {
    * @returns {Promise}
    */
   validate() {
-    return super.validate().then(() => {
+    return super.validate().then(token => {
+      this._tokenIsValid = token;
+
       if (this._tokenIsValid && logs) {
         this.logger.updateContext({ canLogBeSentToApi: true });
       }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #795, #804, #802  

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [x] THUB_TOKEN=##### THUB_API=#### terrahub component 
- [x] THUB_TOKEN=##### THUB_API=#### terrahub project
- [x]  AWS_ACCOUNT_ID="$(aws sts get-caller-identity --output=text --query='Account')" \
        terrahub configure -c template.locals.account_id="${AWS_ACCOUNT_ID}"


## Checklist:
<!-- please check the boxes that matches your use case -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
