### PR TITLE
fixed skip automatically `apply` or `destroy` and `refresh`

### DIFF
--- a/src/commands/apply.js
+++ b/src/commands/apply.js
@@ -27,13 +27,10 @@ class ApplyCommand extends TerraformCommand {
 
     return this.askForApprovement(config, this.getOption('auto-approve'))
       .then(answer => answer ?
-        distributor.runActions(['prepare', 'workspaceSelect', 'plan'], {
+        distributor.runActions(['prepare', 'workspaceSelect', 'plan', 'apply'], {
           dependencyDirection: Dictionary.DIRECTION.FORWARD
         }) : Promise.reject('Action aborted')
-      )
-
-      .then(() => distributor.runActions(['apply'], { dependencyDirection: Dictionary.DIRECTION.FORWARD }))
-      .then(() => Promise.resolve('Done'));
+      ).then(() => Promise.resolve('Done'));
   }
 }
 

--- a/src/commands/destroy.js
+++ b/src/commands/destroy.js
@@ -26,15 +26,11 @@ class DestroyCommand extends TerraformCommand {
     this.checkDependencies(config, Dictionary.DIRECTION.REVERSE);
 
     return this.askForApprovement(config, this.getOption('auto-approve'))
-      .then(answer => answer ? distributor.runActions(['prepare', 'init', 'workspaceSelect', 'plan'], {
+      .then(answer => answer ? distributor.runActions(['prepare', 'init', 'workspaceSelect', 'plan', 'destroy'], {
           planDestroy: true,
           dependencyDirection: Dictionary.DIRECTION.REVERSE
-        }) : Promise.reject('Action aborted'))
-      .then(() => distributor.runActions(['destroy'], {
-        planDestroy: true,
-        dependencyDirection: Dictionary.DIRECTION.REVERSE
-      }))
-      .then(() => Promise.resolve('Done'));
+        }) : Promise.reject('Action aborted')
+      ).then(() => Promise.resolve('Done'));
   }
 }
 


### PR DESCRIPTION
## Description
- fixed skip automatically `apply` or `destroy` 
- fixed `refresh` with local tfstate

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
### Test with skip automatically `apply` or `destroy`
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone# terrahub run -i landing_zone_vpc -a -y
💡 THUB_TOKEN is not provided.
Project: terraform-aws-landing-zone
 └─ landing_zone_vpc
Option 'auto-approve' is enabled, therefore 'run' action is executed with no confirmation.
💡 [landing_zone_vpc] terraform init -no-color -force-copy -input=false .
[landing_zone_vpc]
[landing_zone_vpc] Initializing the backend...
[landing_zone_vpc]
[landing_zone_vpc] Initializing provider plugins...
[landing_zone_vpc]
[landing_zone_vpc] The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

[landing_zone_vpc] * provider.aws: version = "~> 2.24"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
💡 [landing_zone_vpc] terraform workspace list
[landing_zone_vpc] * default

💡 [landing_zone_vpc] terraform plan -no-color -var-file='/root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/default.tfvars' -out=/root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/terraform.tfplan -input=false
[landing_zone_vpc] Refreshing Terraform state in-memory prior to plan...
[landing_zone_vpc] The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[landing_zone_vpc] aws_vpc.landing_zone_vpc[0]: Refreshing state... [id=vpc-xxxxxxxx]
[landing_zone_vpc]
------------------------------------------------------------------------
[landing_zone_vpc]
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
[landing_zone_vpc] configuration and real physical resources that exist. As a result, no
actions need to be performed.
💡 Action 'apply' for 'landing_zone_vpc' was skipped due to 'No changes. Infrastructure is up-to-date.'
✅ Done
```

```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone# terrahub apply -i landing_zone_vpc -y
💡 THUB_TOKEN is not provided.
Project: terraform-aws-landing-zone
 └─ landing_zone_vpc
Option 'auto-approve' is enabled, therefore 'apply' action is executed with no confirmation.
💡 [landing_zone_vpc] terraform workspace list
[landing_zone_vpc] * default

💡 [landing_zone_vpc] terraform plan -no-color -var-file='/root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/default.tfvars' -out=/root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/terraform.tfplan -input=false
[landing_zone_vpc] Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[landing_zone_vpc] aws_vpc.landing_zone_vpc[0]: Refreshing state... [id=vpc-xxxxxxxx]
[landing_zone_vpc]
------------------------------------------------------------------------
[landing_zone_vpc]
No changes. Infrastructure is up-to-date.

[landing_zone_vpc] This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
💡 [landing_zone_vpc] terraform apply -no-color -backup=/mnt/c/Terrahub/terraform-aws-landing-zone/components/landing_zone_vpc/.backup/tfstate/terraform.tfstate.1566211951808.backup -auto-approve=true -input=false /root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/terraform.tfplan
[landing_zone_vpc]
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
[landing_zone_vpc]
Outputs:
[landing_zone_vpc] {
  "default" = [
    "arn:aws:ec2:us-east-1:xxxxxxxxxxxx:vpc/vpc-xxxxxxxx",
  ]
}
ids = {
  "default" = [
    "vpc-xxxxxxxx",
  ]
}
landing_zone_vpc_arns = {
  "default" = [
    "arn:aws:ec2:us-east-1:xxxxxxxxxxxx:vpc/vpc-xxxxxxxx",
  ]
}
landing_zone_vpc_ids = {
  "default" = [
    "vpc-xxxxxxxx",
  ]
}
thub_ids = {
  "default" = [
    "vpc-xxxxxxxx",
  ]
}
✅ Done
```

### Test command `refresh` with local tfstate
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-landing-zone# terrahub refresh -i landing_zone_vpc
💡 THUB_TOKEN is not provided.
Project: terraform-aws-landing-zone
 └─ landing_zone_vpc
💡 'terrahub refresh' action is executed for above list of components.
💡 [landing_zone_vpc] terraform workspace list
[landing_zone_vpc] * default

💡 [landing_zone_vpc] terraform refresh -no-color -backup=/mnt/c/Terrahub/terraform-aws-landing-zone/components/landing_zone_vpc/.backup/tfstate/terraform.tfstate.1566214932620.backup -input=false -var-file='/root/.terrahub/cache/jit/landing_zone_vpc_eef16dcf/default.tfvars' -state='/tmp/.terrahub/tfstate_local/terraform-aws-landing-zone/landing_zone_vpc/terraform.tfstate'
[landing_zone_vpc] aws_vpc.landing_zone_vpc[0]: Refreshing state... [id=vpc-xxxxxxxx]
[landing_zone_vpc] {
  "default" = [
[landing_zone_vpc] {
  "default" = [
[landing_zone_vpc] {
  "default" = [
    "arn:aws:ec2:us-east-1:xxxxxxxxxxxx:vpc/vpc-xxxxxxxx",
  ]
}
landing_zone_vpc_ids = {
  "default" = [
    "vpc-xxxxxxxx",
  ]
}
[landing_zone_vpc] {
  "default" = [
    "vpc-xxxxxxxx",
  ]
}
✅ Done
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
