### PR TITLE
`dependsOn` use terrahub component & define `terraform_remote_state` data when using `dependsOn`

### DIFF
--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -221,7 +221,6 @@ class ConfigLoader {
         cfg.root = root;
 
         delete this._rootConfig[key];
-
         this._processComponentConfig(cfg, root);
         const hash = ConfigLoader.buildComponentHash(root);
         this._config[hash] = extend({}, [this._componentDefaults(), this._rootConfig, cfg]);
@@ -288,10 +287,6 @@ class ConfigLoader {
       if (!Array.isArray(config.dependsOn)) {
         throw new Error(`Error in component's configuration! DependsOn of '${config.name}' must be an array!`);
       }
-
-      config.dependsOn.forEach((dep, index) => {
-        config.dependsOn[index] = this.relativePath(path.resolve(this._rootPath, componentPath, dep));
-      });
     }
 
     if (config.hasOwnProperty('mapping')) {

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -494,7 +494,7 @@ class TerraformCommand extends AbstractCommand {
 
     const messages = Object.keys(issues).filter(it => issues[it].length).map(it => {
       return `'${config[it].name}' component depends on the component${issues[it].length > 1 ? 's' : ''} ` +
-        `'${issues[it].join(`', '`)}' that doesn't exist`;
+        `'${issues[it].join(`', '`)}' that either are not included or do not exist`;
     });
 
     if (messages.length) {

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -202,9 +202,7 @@ class TerraformCommand extends AbstractCommand {
    * @private
    */
   _createHashFromName(componentConfig) {
-    const dependentRelativePath = componentConfig.root;
-
-    return ConfigLoader.buildComponentHash(dependentRelativePath);
+    return ConfigLoader.buildComponentHash(componentConfig.root);
   }
 
   /**

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -197,15 +197,6 @@ class TerraformCommand extends AbstractCommand {
   }
 
   /**
-   * @param {Object} componentConfig
-   * @return {String|boolean}
-   * @private
-   */
-  _createHashFromName(componentConfig) {
-    return ConfigLoader.buildComponentHash(componentConfig.root);
-  }
-
-  /**
    * @param {Object} config
    * @private
    */
@@ -218,7 +209,7 @@ class TerraformCommand extends AbstractCommand {
 
         this.processRemoteStateTemplate(config, dependentConfig, hash);
 
-        return this._createHashFromName(dependentConfig);
+        return ConfigLoader.buildComponentHash(dependentConfig.root);
       });
 
       node.dependsOn = Util.arrayToObject(dependsOn);
@@ -484,7 +475,7 @@ class TerraformCommand extends AbstractCommand {
         }
 
         const dependentConfig = config[dependentComponent];
-        const key = this._createHashFromName(dependentConfig);
+        const key = ConfigLoader.buildComponentHash(dependentConfig.root);
 
         return !config.hasOwnProperty(key);
       });

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -234,7 +234,7 @@ class TerraformCommand extends AbstractCommand {
   processRemoteStateTemplate(config, dependentConfig, hash) {
     const { project, template, name } = dependentConfig;
     const configBackendExist = template.terraform && template.terraform.backend;
-    const cachedBackendPath = Util.homePath('cache/hcl', `${name}_${project.code}`, 'terraform.tfstate');
+    const cachedBackendPath = Util.homePath(hclPath, `${name}_${project.code}`, 'terraform.tfstate');
     const cachedBackendExist = fs.existsSync(cachedBackendPath);
 
     if (!(configBackendExist || cachedBackendExist)) { return; }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #744, #860 

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
```
component:
  name: 4-test
  dependsOn: [1-test, 2-test, 3-test]
  template:
    terraform:
      backend:
        s3:
          key: path/to/4-tester/terraform.tfstate
          bucket: bucket_name
          region: us-east-1
    resource:
      aws_ssm_parameter:
        parameter_name:
          name: 4-test-name
          value: "${data.terraform_remote_state.3-test.text}${data.terraform_remote_state.2-test.text}${data.terraform_remote_state.1-test.text}"
          type: String
```
```
component:
  name: 3-test
  template:
    terraform:
      backend:
        local:
          path: "/path/to/terraform.tfstate"
    resource:
      aws_ssm_parameter:
        parameter_name:
          name: 3-test-name
          value: 3-test_value
          type: String
    output:
      text:
        value: "from 3-test component"
```
```
component:
  name: 2-test
  template:
    terraform:
      backend:
        s3:
          key: path/to/terraform.tfstate
          bucket: bucket_name
          region: us-east-1
    resource:
      aws_ssm_parameter:
        parameter_name:
          name: 2-test-name
          value: 2-test_value
          type: String
    output:
      test:
        value: "from 2-test component"
```
```
component:
  name: 1-test
  template:
    resource:
      aws_ssm_parameter:
        parameter_name:
          name: 1-test-name
          value: 1-test_value
          type: String
    output:
      test:
        value: "from 1-test component"
```
## OUTPUT:
### First run for dependent components'

` thub run -i 1-test,2-test,3-test -a  -y`

```
💡 THUB_TOKEN is not provided.
Project: tester-project-012
 ├─ 1-test
 ├─ 2-test
 └─ 3-test
Option 'auto-approve' is enabled, therefore 'run' action is executed with no confirmation.
💡 [1-test] terraform init -no-color -force-copy -input=false .
💡 [2-test] terraform init -no-color -force-copy -input=false .
[1-test] 
Initializing provider plugins...
[2-test] 
[2-test] Initializing the backend...
💡 [3-test] terraform init -no-color -force-copy -input=false .
[3-test] 
Initializing the backend...
[3-test] 
Initializing provider plugins...
[1-test] 
[1-test] The following providers do not have any version constraints in configuration,
[1-test] so the latest version was installed.

[1-test] To prevent automatic upgrades to new major versions that may contain breaking
[1-test] changes, it is recommended to add version = "..." constraints to the
[1-test] corresponding provider blocks in configuration, with the constraint strings
[1-test] suggested below.

[1-test] * provider.aws: version = "~> 2.32"
[1-test] 
[1-test] Terraform has been successfully initialized!
[1-test] 
[1-test] You may now begin working with Terraform. Try running "terraform plan" to see
[1-test] any changes that are required for your infrastructure. All Terraform commands
[1-test] should now work.

[1-test] If you ever set or change modules or backend configuration for Terraform,
[1-test] rerun this command to reinitialize your working directory. If you forget, other
[1-test] commands will detect it and remind you to do so if necessary.
💡 [1-test] terraform workspace list
[1-test] * default
[1-test] 
[3-test] 
[3-test] The following providers do not have any version constraints in configuration,
[3-test] so the latest version was installed.

[3-test] To prevent automatic upgrades to new major versions that may contain breaking
[3-test] changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.32"

[3-test] Terraform has been successfully initialized!
[3-test] 
[3-test] You may now begin working with Terraform. Try running "terraform plan" to see
[3-test] any changes that are required for your infrastructure. All Terraform commands
[3-test] should now work.

[3-test] If you ever set or change modules or backend configuration for Terraform,
[3-test] rerun this command to reinitialize your working directory. If you forget, other
[3-test] commands will detect it and remind you to do so if necessary.
💡 [3-test] terraform workspace list
[3-test] * default

[2-test] 
[2-test] Initializing provider plugins...
[2-test] 
[2-test] The following providers do not have any version constraints in configuration,
so the latest version was installed.

[2-test] To prevent automatic upgrades to new major versions that may contain breaking
[2-test] changes, it is recommended to add version = "..." constraints to the
[2-test] corresponding provider blocks in configuration, with the constraint strings
[2-test] suggested below.

[2-test] * provider.aws: version = "~> 2.32"

[2-test] Terraform has been successfully initialized!
[2-test] 
[2-test] You may now begin working with Terraform. Try running "terraform plan" to see
[2-test] any changes that are required for your infrastructure. All Terraform commands
should now work.

[2-test] If you ever set or change modules or backend configuration for Terraform,
[2-test] rerun this command to reinitialize your working directory. If you forget, other
[2-test] commands will detect it and remind you to do so if necessary.
💡 [2-test] terraform workspace list
[2-test] * default

💡 [1-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/1-test_3112aba2/terraform.tfplan -input=false
💡 [3-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfplan -input=false
💡 [2-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/2-test_3112aba2/terraform.tfplan -input=false
[1-test] Refreshing Terraform state in-memory prior to plan...
[1-test] The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[1-test] 
[1-test] ------------------------------------------------------------------------
[3-test] Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[3-test] 
------------------------------------------------------------------------
[1-test] 
[1-test] An execution plan has been generated and is shown below.
[1-test] Resource actions are indicated with the following symbols:
[1-test]   + create

Terraform will perform the following actions:

[1-test] + aws_ssm_parameter.parameter_name
[1-test]       id:      <computed>
[1-test]       arn:     <computed>
      key_id:  <computed>
[1-test]       name:    "1-test-name"
      tier:    "Standard"
[1-test]       type:    "String"
      value:   <sensitive>
[1-test]       version: <computed>
[1-test] Plan: 1 to add, 0 to change, 0 to destroy.

[1-test] ------------------------------------------------------------------------

[1-test] This plan was saved to: /Users/andreyluchianic/.terrahub/cache/hcl/1-test_3112aba2/terraform.tfplan

To perform exactly these actions, run the following command to apply:
[1-test]     terraform apply "/Users/andreyluchianic/.terrahub/cache/hcl/1-test_3112aba2/terraform.tfplan"

💡 [1-test] terraform apply -no-color -backup=/Users/andreyluchianic/WebstormProjects/terrahub-cli-test/tester/1-tester/.backup/tfstate/terraform.tfstate.1571229945428.backup -auto-approve=true -input=false /Users/andreyluchianic/.terrahub/cache/hcl/1-test_3112aba2/terraform.tfplan
[3-test] 
[3-test] An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
[3-test]   + create

Terraform will perform the following actions:
[3-test] 
[3-test] + aws_ssm_parameter.parameter_name
      id:      <computed>
[3-test]       arn:     <computed>
[3-test]       key_id:  <computed>
      name:    "3-test-name"
[3-test]       tier:    "Standard"
      type:    "String"
[3-test]       value:   <sensitive>
[3-test]       version: <computed>
[3-test] Plan: 1 to add, 0 to change, 0 to destroy.

[3-test] ------------------------------------------------------------------------
[3-test] 
[3-test] This plan was saved to: /Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "/Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfplan"

💡 [3-test] terraform apply -no-color -backup=/Users/andreyluchianic/WebstormProjects/terrahub-cli-test/tester/3-tester/.backup/tfstate/terraform.tfstate.1571229945702.backup -auto-approve=true -input=false /Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfplan
[2-test] Refreshing Terraform state in-memory prior to plan...
[2-test] The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[1-test] aws_ssm_parameter.parameter_name: Creating...
[1-test]   arn:     "" => "<computed>"
  key_id:  "" => "<computed>"
[1-test]   name:    "" => "1-test-name"
[1-test]   tier:    "" => "Standard"
  type:    "" => "String"
[1-test]   value:   "<sensitive>" => "<sensitive>"
  version: "" => "<computed>"
[3-test] aws_ssm_parameter.parameter_name: Creating...
[3-test]   arn:     "" => "<computed>"
  key_id:  "" => "<computed>"
  name:    "" => "3-test-name"
  tier:    "" => "Standard"
  type:    "" => "String"
[3-test]   value:   "<sensitive>" => "<sensitive>"
  version: "" => "<computed>"
[2-test] aws_ssm_parameter.parameter_name: Refreshing state... (ID: 2-test-name)
[2-test] 
[2-test] ------------------------------------------------------------------------
[1-test] aws_ssm_parameter.parameter_name: Creation complete after 3s (ID: 1-test-name)
[1-test] 
[1-test] Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

text = from 1-test
[3-test] aws_ssm_parameter.parameter_name: Creation complete after 2s (ID: 3-test-name)
[3-test] 
[3-test] Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
[3-test] 
The state of your infrastructure has been saved to the path
[3-test] below. This state is required to modify and destroy your
[3-test] infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

[3-test] State path: /Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfstate
[3-test] 
Outputs:

text = from 3-test
[2-test] 
[2-test] An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

[2-test] Terraform will perform the following actions:

[2-test] + aws_ssm_parameter.lambda_deployer_test_parameter
      id:      <computed>
      arn:     <computed>
      key_id:  <computed>
      name:    "2-test-name"
[2-test]       tier:    "Standard"
      type:    "String"
      value:   <sensitive>
      version: <computed>
Plan: 1 to add, 0 to change, 0 to destroy.

[2-test] ------------------------------------------------------------------------

[2-test] This plan was saved to: /Users/andreyluchianic/.terrahub/cache/hcl/2-test_3112aba2/terraform.tfplan

[2-test] To perform exactly these actions, run the following command to apply:
[2-test]     terraform apply "/Users/andreyluchianic/.terrahub/cache/hcl/2-test_3112aba2/terraform.tfplan"

💡 [2-test] terraform apply -no-color -backup=/Users/andreyluchianic/WebstormProjects/terrahub-cli-test/tester/2-tester/.backup/tfstate/terraform.tfstate.1571229953807.backup -auto-approve=true -input=false /Users/andreyluchianic/.terrahub/cache/hcl/2-test_3112aba2/terraform.tfplan
[2-test] aws_ssm_parameter.lambda_deployer_test_parameter: Creating...
[2-test]   arn:     "" => "<computed>"
  key_id:  "" => "<computed>"
  name:    "" => "2-test-name"
  tier:    "" => "Standard"
[2-test]   type:    "" => "String"
[2-test]   value:   "<sensitive>" => "<sensitive>"
  version: "" => "<computed>"
[2-test] aws_ssm_parameter.parameter_name: Creation complete after 2s (ID: 2-test-name)
[2-test] 
[2-test] Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

[2-test] text = from 2-test
✅ Done
```
### Second run for main component with hist dependencies 

`thub run -i 4-test -p include -a -y`

```
💡 THUB_TOKEN is not provided.
Terrahub added '1-test' component that is dependency of '4-test' component
Terrahub added '2-test' component that is dependency of '4-test' component
Terrahub added '3-test' component that is dependency of '4-test' component
Project: tester-project-012
 ├─ 4-test
 ├─ 1-test
 ├─ 2-test
 └─ 3-test
Option 'auto-approve' is enabled, therefore 'run' action is executed with no confirmation.
💡 [4-test] terraform init -no-color -force-copy -input=false .
💡 [2-test] terraform init -no-color -force-copy -input=false .
[4-test] 
Initializing the backend...
💡 [1-test] terraform init -no-color -force-copy -input=false .
[2-test] 
Initializing the backend...
[1-test] 
Initializing provider plugins...
💡 [3-test] terraform init -no-color -force-copy -input=false .
[3-test] 
Initializing the backend...
[3-test] 
[3-test] Initializing provider plugins...
[1-test] 
[1-test] The following providers do not have any version constraints in configuration,
so the latest version was installed.

[1-test] To prevent automatic upgrades to new major versions that may contain breaking
[1-test] changes, it is recommended to add version = "..." constraints to the
[1-test] corresponding provider blocks in configuration, with the constraint strings
suggested below.
[1-test] 
* provider.aws: version = "~> 2.32"
[1-test] 
[1-test] Terraform has been successfully initialized!
[1-test] 
[1-test] You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
[1-test] rerun this command to reinitialize your working directory. If you forget, other
[1-test] commands will detect it and remind you to do so if necessary.
💡 [1-test] terraform workspace list
[1-test] * default

[3-test] 
[3-test] The following providers do not have any version constraints in configuration,
[3-test] so the latest version was installed.

[3-test] To prevent automatic upgrades to new major versions that may contain breaking
[3-test] changes, it is recommended to add version = "..." constraints to the
[3-test] corresponding provider blocks in configuration, with the constraint strings
suggested below.

[3-test] * provider.aws: version = "~> 2.32"
[3-test] 
[3-test] Terraform has been successfully initialized!

[3-test] You may now begin working with Terraform. Try running "terraform plan" to see
[3-test] any changes that are required for your infrastructure. All Terraform commands
should now work.

[3-test] If you ever set or change modules or backend configuration for Terraform,
[3-test] rerun this command to reinitialize your working directory. If you forget, other
[3-test] commands will detect it and remind you to do so if necessary.
💡 [3-test] terraform workspace list
[3-test] * default

[4-test] 
[4-test] Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
[2-test] 
[2-test] Initializing provider plugins...
[4-test] - Downloading plugin for provider "aws" (2.32.0)...
[2-test] 
[2-test] The following providers do not have any version constraints in configuration,
[2-test] so the latest version was installed.

[2-test] To prevent automatic upgrades to new major versions that may contain breaking
[2-test] changes, it is recommended to add version = "..." constraints to the
[2-test] corresponding provider blocks in configuration, with the constraint strings
[2-test] suggested below.

* provider.aws: version = "~> 2.32"
[2-test] 
Terraform has been successfully initialized!

[2-test] You may now begin working with Terraform. Try running "terraform plan" to see
[2-test] any changes that are required for your infrastructure. All Terraform commands
should now work.

[2-test] If you ever set or change modules or backend configuration for Terraform,
[2-test] rerun this command to reinitialize your working directory. If you forget, other
[2-test] commands will detect it and remind you to do so if necessary.
💡 [2-test] terraform workspace list
[2-test] * default

[4-test] 
[4-test] The following providers do not have any version constraints in configuration,
[4-test] so the latest version was installed.

[4-test] To prevent automatic upgrades to new major versions that may contain breaking
[4-test] changes, it is recommended to add version = "..." constraints to the
[4-test] corresponding provider blocks in configuration, with the constraint strings
[4-test] suggested below.
[4-test] 
[4-test] * provider.aws: version = "~> 2.32"

[4-test] Terraform has been successfully initialized!
[4-test] 
[4-test] You may now begin working with Terraform. Try running "terraform plan" to see
[4-test] any changes that are required for your infrastructure. All Terraform commands
should now work.
[4-test] 
[4-test] If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
[4-test] commands will detect it and remind you to do so if necessary.
💡 [4-test] terraform workspace list
[4-test] * default
[4-test] 
💡 [3-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/3-test_3112aba2/terraform.tfplan -input=false
💡 [2-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/2-test_3112aba2/terraform.tfplan -input=false
💡 [1-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/1-test_3112aba2/terraform.tfplan -input=false
[3-test] Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
[3-test] persisted to local or remote state storage.

[1-test] Refreshing Terraform state in-memory prior to plan...
[1-test] The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[1-test] aws_ssm_parameter.parameter_name: Refreshing state... (ID: 1-test-name)
[3-test] aws_ssm_parameter.parameter_name: Refreshing state... (ID: 3-test-name)
[2-test] Refreshing Terraform state in-memory prior to plan...
[2-test] The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[1-test] 
[1-test] ------------------------------------------------------------------------
[3-test] 
[3-test] ------------------------------------------------------------------------
[1-test] 
[1-test] No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
[1-test] configuration and real physical resources that exist. As a result, no
actions need to be performed.
💡 Action 'apply' for '1-test' was skipped due to 'No changes. Infrastructure is up-to-date.'
[2-test] aws_ssm_parameter.parameter_name: Refreshing state... (ID: 2-test-name)
[3-test] 
[3-test] No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
[3-test] configuration and real physical resources that exist. As a result, no
actions need to be performed.
💡 Action 'apply' for '3-test' was skipped due to 'No changes. Infrastructure is up-to-date.'
[2-test] 
[2-test] ------------------------------------------------------------------------
[2-test] 
[2-test] No changes. Infrastructure is up-to-date.

[2-test] This means that Terraform did not detect any differences between your
[2-test] configuration and real physical resources that exist. As a result, no
actions need to be performed.
💡 Action 'apply' for '2-test' was skipped due to 'No changes. Infrastructure is up-to-date.'
💡 [4-test] terraform plan -no-color -out=/Users/andreyluchianic/.terrahub/cache/hcl/4-test_3112aba2/terraform.tfplan -input=false
[4-test] Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
[4-test] persisted to local or remote state storage.

[4-test] data.terraform_remote_state.2-test: Refreshing state...
[4-test] data.terraform_remote_state.3-test: Refreshing state...
[4-test] data.terraform_remote_state.1-test: Refreshing state...
[4-test] aws_ssm_parameter.parameter_name: Refreshing state... (ID: 4-test-name)
[4-test] 
------------------------------------------------------------------------
[4-test] 
[4-test] An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

[4-test] Terraform will perform the following actions:

+ aws_ssm_parameter.parameter_name
[4-test]       id:      <computed>
      arn:     <computed>
      key_id:  <computed>
      name:    "4-test-name"
      tier:    "Standard"
      type:    "String"
      value:   <sensitive>
[4-test]       version: <computed>
Plan: 1 to add, 0 to change, 0 to destroy.

[4-test] ------------------------------------------------------------------------
[4-test] 
[4-test] This plan was saved to: /Users/andreyluchianic/.terrahub/cache/hcl/4-test_3112aba2/terraform.tfplan

To perform exactly these actions, run the following command to apply:
[4-test]     terraform apply "/Users/andreyluchianic/.terrahub/cache/hcl/4-test_3112aba2/terraform.tfplan"

💡 [4-test] terraform apply -no-color -backup=/Users/andreyluchianic/WebstormProjects/terrahub-cli-test/tester/4-tester/.backup/tfstate/terraform.tfstate.1571230051657.backup -auto-approve=true -input=false /Users/andreyluchianic/.terrahub/cache/hcl/4-test_3112aba2/terraform.tfplan
[4-test] aws_ssm_parameter.parameter_name: Creating...
  arn:     "" => "<computed>"
  key_id:  "" => "<computed>"
  name:    "" => "4-test-name"
  tier:    "" => "Standard"
  type:    "" => "String"
  value:   "<sensitive>" => "<sensitive>"
  version: "" => "<computed>"
[4-test] aws_ssm_parameter.parameter_name: Creation complete after 3s (ID: 4-test-name)
[4-test] 
[4-test] Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
✅ Done


```


## Checklist:
<!-- please check the boxes that matches your use case -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
