### PR TITLE
add warning when using cloud/tfvars/backend Accounts without THUB_TOKEN

### DIFF
--- a/src/abstract-command.js
+++ b/src/abstract-command.js
@@ -297,6 +297,21 @@ class AbstractCommand {
     this.logger.warn('THUB_TOKEN is not provided.');
     return Promise.resolve();
   }
+
+  /**
+   * @param {Object} fullConfig
+   * @return {void}
+   */
+  checkCloudAccountRequirements(fullConfig) {
+    Object.keys(fullConfig).forEach(hash => {
+      const accounts = fullConfig[hash].terraform && Object.keys(fullConfig[hash].terraform)
+        .filter(it => /Account/.test(it));
+      if (accounts.length) {
+        this.logger.warn(`If you want to use '${accounts.join('\', \'')}' in '${fullConfig[hash].name}' component ` +
+          `please provide THUB_TOKEN.`);
+      }
+    });
+  }
 }
 
 module.exports = AbstractCommand;

--- a/src/helpers/wrappers/terraform.js
+++ b/src/helpers/wrappers/terraform.js
@@ -95,13 +95,8 @@ class Terraform {
    * @private
    */
   async _setupVars() {
-    if (!process.env.THUB_TOKEN_IS_VALID.length) {
-      return Promise.resolve();
-    }
-
     const accounts = Object.keys(this._tf).filter(it => /Account/.test(it));
-
-    if (!accounts.length) {
+    if (!accounts.length || !process.env.THUB_TOKEN_IS_VALID.length) {
       return Promise.resolve();
     }
 

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -62,9 +62,8 @@ class TerraformCommand extends AbstractCommand {
     return super.validate().then(token => {
       this._tokenIsValid = token;
 
-      if (this._tokenIsValid && logs) {
-        this.logger.updateContext({ canLogBeSentToApi: true });
-      }
+      if (this._tokenIsValid && logs) { this.logger.updateContext({ canLogBeSentToApi: true }); }
+      if (!this._tokenIsValid) { this.checkCloudAccountRequirements(this.getExtendedConfig()); }
 
       return Promise.resolve();
     }).then(() => this._checkProjectDataMissing()).then(() => {
@@ -83,7 +82,6 @@ class TerraformCommand extends AbstractCommand {
 
       return Promise.resolve();
     }).then(() => this._checkProjectDuplicateComponents())
-      .then(() => this._checkCloudAccountsRequirements())
       .catch(err => {
         const error = err.constructor === String ? new Error(err) : err;
 
@@ -125,22 +123,6 @@ class TerraformCommand extends AbstractCommand {
       throw new ListException(messages, {
         header: 'Some components have duplicates in project:',
         style: ListException.NUMBER
-      });
-    }
-
-    return Promise.resolve();
-  }
-
-  _checkCloudAccountsRequirements() {
-    if (!this._tokenIsValid) {
-      const fullConfig = this.getExtendedConfig();
-      Object.keys(fullConfig).forEach(hash => {
-        const accounts = fullConfig[hash].terraform && Object.keys(fullConfig[hash].terraform)
-          .filter(it => /Account/.test(it));
-        if (accounts.length) {
-          this.logger.warn(`If you want to use '${accounts.join('\', \'')}' in '${fullConfig[hash].name}' component ` +
-            `please provide THUB_TOKEN.`);
-        }
       });
     }
 
@@ -216,6 +198,10 @@ class TerraformCommand extends AbstractCommand {
     return result;
   }
 
+  /**
+   * @param {Object} config
+   * @private
+   */
   _processRemoteStates(config) {
     Object.keys(config).forEach(hash => {
       const node = config[hash];
@@ -300,7 +286,7 @@ class TerraformCommand extends AbstractCommand {
         const thubKeyWord = 'tfvars.terrahub';
         const path = variable.slice(2, -1);
         const property = getPropertyFromPath(dependentConfig.template, path.replace(thubKeyWord, 'local'))
-          || getPropertyFromPath(dependentConfig.template, path.replace(thubKeyWord, 'tfvars')) ;
+          || getPropertyFromPath(dependentConfig.template, path.replace(thubKeyWord, 'tfvars'));
         if (!property) {
           this._errors.push({ name, variable });
         }
@@ -318,9 +304,9 @@ class TerraformCommand extends AbstractCommand {
    * @return {Boolean}
    * @private
    */
- _remoteStateExist(hash, name) {
-    return this._terraformRemoteStates[hash] && this._terraformRemoteStates[hash].find(it => it.component === name)
- }
+  _remoteStateExist(hash, name) {
+    return this._terraformRemoteStates[hash] && this._terraformRemoteStates[hash].find(it => it.component === name);
+  }
 
   /**
    * Defines terraform_remote_state from dependencies
@@ -374,12 +360,13 @@ class TerraformCommand extends AbstractCommand {
 
   /**
    * @param {Object} config
+   * @param {String} hash
    * @private
    */
   _createTerraformRemoteStateObject(config, hash) {
     if (!config[hash].template.data) {
-      config[hash].template.data = { 'terraform_remote_state': {}};
-    } else if(!config[hash].template.data['terraform_remote_state']) {
+      config[hash].template.data = { 'terraform_remote_state': {} };
+    } else if (!config[hash].template.data['terraform_remote_state']) {
       config[hash].template.data['terraform_remote_state'] = {};
     }
   }

--- a/src/terraform-command.js
+++ b/src/terraform-command.js
@@ -83,6 +83,7 @@ class TerraformCommand extends AbstractCommand {
 
       return Promise.resolve();
     }).then(() => this._checkProjectDuplicateComponents())
+      .then(() => this._checkCloudAccountsRequirements())
       .catch(err => {
         const error = err.constructor === String ? new Error(err) : err;
 
@@ -124,6 +125,22 @@ class TerraformCommand extends AbstractCommand {
       throw new ListException(messages, {
         header: 'Some components have duplicates in project:',
         style: ListException.NUMBER
+      });
+    }
+
+    return Promise.resolve();
+  }
+
+  _checkCloudAccountsRequirements() {
+    if (!this._tokenIsValid) {
+      const fullConfig = this.getExtendedConfig();
+      Object.keys(fullConfig).forEach(hash => {
+        const accounts = fullConfig[hash].terraform && Object.keys(fullConfig[hash].terraform)
+          .filter(it => /Account/.test(it));
+        if (accounts.length) {
+          this.logger.warn(`If you want to use '${accounts.join('\', \'')}' in '${fullConfig[hash].name}' component ` +
+            `please provide THUB_TOKEN.`);
+        }
       });
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #843 

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [ ] add cloud/tfvars/backend account to component
- [ ] thub run (without THUB_TOKEN)

```
➜ thub run -a -y -i test-1
💡 THUB_TOKEN is not provided.
💡 If you want to use 'cloudAccount', 'tfvarsAccount' in 'test-1' component please provide THUB_TOKEN.
Project: tester-project-012
 └─ test-1
Option 'auto-approve' is enabled, therefore 'run' action is executed with no confirmation.
```


## Checklist:
<!-- please check the boxes that matches your use case -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
