### PR TITLE
fixed issue #910

### DIFF
--- a/src/helpers/hcl-helper.js
+++ b/src/helpers/hcl-helper.js
@@ -646,7 +646,7 @@ class HclHelper {
           name = 'main.tf';
           break;
         case 'tfvars':
-          name = join(`${cfgEnv}.tfvars`);
+          name = join(cfgEnv === 'default' ? '' : 'workspace', `${cfgEnv}.tfvars`);
           data = template[it];
           break;
       }

--- a/src/helpers/hcl-helper.js
+++ b/src/helpers/hcl-helper.js
@@ -646,7 +646,7 @@ class HclHelper {
           name = 'main.tf';
           break;
         case 'tfvars':
-          name = join(cfgEnv === 'default' ? '' : 'workspace', `${cfgEnv}.tfvars`);
+          name = join(`${cfgEnv}.tfvars`);
           data = template[it];
           break;
       }

--- a/src/helpers/hcl-helper.js
+++ b/src/helpers/hcl-helper.js
@@ -596,17 +596,11 @@ class HclHelper {
       strWithoutQuote = strWithoutQuote.replace(JSON.stringify(`${key}`), `"${value}"`);
     }
 
-    if (strWithoutQuote !== '{}') {
-      const remoteTfvarsJson = JSON.parse(strWithoutQuote);
+    const remoteTfvarsJson = JSON.parse(strWithoutQuote);
 
-      template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}) +
-        JSON.stringify(remoteTfvarsJson)).replace(/}{/g, ",").replace(/{,/g, "{"));
+    template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}) +
+      JSON.stringify(remoteTfvarsJson)).replace(/}{/g, ",").replace(/{,/g, "{").replace(/,}/g, "}"));
 
-      return Promise.resolve();
-    }
-
-    template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}))
-      .replace(/}{/g, ",").replace(/{,/g, "{"));
     return Promise.resolve();
   }
 
@@ -652,7 +646,7 @@ class HclHelper {
           name = 'main.tf';
           break;
         case 'tfvars':
-          name = join(cfgEnv === 'default' ? '' : 'workspace', `${cfgEnv}.tfvars`);
+          name = join(`${cfgEnv}.tfvars`);
           data = template[it];
           break;
       }

--- a/src/helpers/hcl-helper.js
+++ b/src/helpers/hcl-helper.js
@@ -596,11 +596,17 @@ class HclHelper {
       strWithoutQuote = strWithoutQuote.replace(JSON.stringify(`${key}`), `"${value}"`);
     }
 
-    const remoteTfvarsJson = JSON.parse(strWithoutQuote);
+    if (strWithoutQuote !== '{}') {
+      const remoteTfvarsJson = JSON.parse(strWithoutQuote);
 
-    template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}) +
-      JSON.stringify(remoteTfvarsJson)).replace(/}{/g, ",").replace(/{,/g, "{"));
+      template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}) +
+        JSON.stringify(remoteTfvarsJson)).replace(/}{/g, ",").replace(/{,/g, "{"));
 
+      return Promise.resolve();
+    }
+
+    template['tfvars'] = JSON.parse((JSON.stringify(config.template.tfvars || {}))
+      .replace(/}{/g, ",").replace(/{,/g, "{"));
     return Promise.resolve();
   }
 

--- a/src/helpers/hcl-helper.js
+++ b/src/helpers/hcl-helper.js
@@ -646,7 +646,7 @@ class HclHelper {
           name = 'main.tf';
           break;
         case 'tfvars':
-          name = join(`${cfgEnv}.tfvars`);
+          name = `${cfgEnv}.tfvars`;
           data = template[it];
           break;
       }


### PR DESCRIPTION
## Description
- fixed issue #910 

## Type of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
### component tree
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-control-tower# ls -al components/landing_zone_vpc/
total 12
drwxrwxrwx 1 euliancom euliancom  512 Oct 30 14:50 .
drwxrwxrwx 1 euliancom euliancom  512 Oct 30 10:35 ..
-rwxrwxrwx 1 euliancom euliancom  863 Oct 30 11:34 default.tfvars
-rwxrwxrwx 1 euliancom euliancom   54 Oct 30 13:50 master.tfvars
-rwxrwxrwx 1 euliancom euliancom   52 Aug 14 10:05 README.md
-rwxrwxrwx 1 euliancom euliancom 2351 Oct 29 14:32 .terrahub.yml
```

### `.terrahub.master.yml` from root folder
```
terraform:
  varFile:
    - default.tfvars
    - master.tfvars
```

### `master.tfvars` from component folder
```
################
#     test     #
################
``` 

### run command `terrahub run`
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-control-tower# terrahub run -i landing_zone_vpc -e master
💡 THUB_TOKEN is not provided.
Project: terraform-aws-landing-zone
 └─ landing_zone_vpc
💡 'terrahub run' action is executed for above list of components.
💡 [landing_zone_vpc] terraform init -no-color -force-copy -input=false .
[landing_zone_vpc]
[landing_zone_vpc] Initializing the backend...
[landing_zone_vpc]
[landing_zone_vpc] Initializing provider plugins...
- Checking for available provider plugins...
[landing_zone_vpc] - Downloading plugin for provider "aws" (hashicorp/aws) 2.33.0...
[landing_zone_vpc]
[landing_zone_vpc] The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
[landing_zone_vpc] corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.33"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
💡 [landing_zone_vpc] terraform workspace list
[landing_zone_vpc] * default

💡 [landing_zone_vpc] terraform workspace new master
[landing_zone_vpc] Created and switched to workspace "master"!

You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
[landing_zone_vpc] for this configuration.
💡 [landing_zone_vpc] terraform plan -no-color -var-file='/root/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/default.tfvars' -var-file='/root/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/master.tfvars' -out=/root/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/terraform.tfstate.d/master/terraform.tfplan -input=false
[landing_zone_vpc] Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

[landing_zone_vpc]
------------------------------------------------------------------------
[landing_zone_vpc]
[landing_zone_vpc] {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
[landing_zone_vpc] {
          + "AWSServiceAccount" = "123456789012"
          + "Description"       = "Managed by TerraHub"
[landing_zone_vpc]           + "Name"              = "VPC for Landing Zone"
          + "ThubCode"          = "1234abcd"
          + "ThubEnv"           = "dev"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

[landing_zone_vpc] This plan was saved to: /root/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/terraform.tfstate.d/master/terraform.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "/root/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/terraform.tfstate.d/master/terraform.tfplan"

✅ Done
```

### component tree in hcl2
```
root@DESKTOP-ECSQPB1:/mnt/c/Terrahub/terraform-aws-control-tower# ls -al ~/.terrahub/cache/hcl/landing_zone_vpc_eef16dcf/
total 12
drwxr-xr-x 1 root root  512 Oct 30 14:52 .
drwxr-xr-x 1 root root  512 Oct 30 13:53 ..
lrwxrwxrwx 1 root root   86 Oct 30 13:53 default.tfvars -> /mnt/c/Terrahub/terraform-aws-control-tower/components/landing_zone_vpc/default.tfvars
-rw-r--r-- 1 root root  638 Oct 30 14:25 locals.tf
-rw-r--r-- 1 root root 1149 Oct 30 14:25 main.tf
-rw-r--r-- 1 root root  855 Oct 30 14:25 master.tfvars
-rw-r--r-- 1 root root  408 Oct 30 14:25 output.tf
-rw-r--r-- 1 root root  420 Oct 30 14:25 provider.tf
lrwxrwxrwx 1 root root   81 Oct 30 13:53 README.md -> /mnt/c/Terrahub/terraform-aws-control-tower/components/landing_zone_vpc/README.md
drwxr-xr-x 1 root root  512 Oct 30 14:25 .terraform
drwxr-xr-x 1 root root  512 Oct 30 14:25 terraform.tfstate.d
-rw-r--r-- 1 root root  289 Oct 30 14:25 variable.tf
```

### Test Configuration
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
