### PR TITLE
fix --git-diff, improve gitDiff error handling

### DIFF
--- a/src/distributed-command.js
+++ b/src/distributed-command.js
@@ -483,7 +483,6 @@ class DistributedCommand extends AbstractCommand {
 
       if (dependsOn) {
         Object.keys(dependsOn)
-          .filter(path => ConfigLoader.buildComponentHash(path))
           .filter(hash => !result.hasOwnProperty(hash))
           .forEach(hash => {
             newHashes.push(hash);

--- a/src/helpers/git-helper.js
+++ b/src/helpers/git-helper.js
@@ -8,7 +8,7 @@ class GitHelper {
   /**
    * @param {Error} error
    * @param {String} appPath
-   * @return {*}
+   * @throws {Error}
    */
   static handleGitDiffError(error, appPath) {
     logger.debug(error);
@@ -20,10 +20,12 @@ class GitHelper {
         message = 'Git is not installed on this device.';
       } else if (/Not a git repository/i.test(stderr)) {
         message = `Git repository not found in '${appPath}'.`;
+      } else {
+        message = stderr;
       }
     }
 
-    return { ...error, message };
+    throw message || error;
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes terrahub --git-diff command & error handling

The error that happend is because when you running `git diff branch1..branch2` - branch1, branch2 should be local branches otherwise command should look like `git diff origin/branch1..origin/branch2`. When running in Jenkins scripts makes checkout on branch1 and branch2 making branches local.

## Type of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
- [x] [LandingZone] terrahub run -g dev..feature/components -i landing_zone_subnet


## Checklist:
<!-- please check the boxes that matches your use case -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
