### PR TITLE
Ignore Missing Terraform Remote States in S3

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -15,6 +15,7 @@ class RunCommand extends DistributedCommand {
       .addOption('apply', 'a', 'Enable apply command as part of automated workflow', Boolean, false)
       .addOption('destroy', 'd', 'Enable destroy command as part of automated workflow', Boolean, false)
       .addOption('auto-approve', 'y', 'Auto approve terraform execution', Boolean, false)
+      .addOption('ignore-missing', 's', 'Ignore missing terraform state(s)', Boolean, false)
       .addOption('dry-run', 'u', 'Prints the list of components that are included in the action', Boolean, false)
       .addOption('build', 'b', 'Enable build command as part of automated workflow', Boolean, false);
   }

--- a/src/helpers/distributors/distributor.js
+++ b/src/helpers/distributors/distributor.js
@@ -187,8 +187,7 @@ class Distributor {
     this._eventEmitter.on('message', (response) => {
       const data = response.data || response;
       if (data.isError) {
-        this.errors.push(data.message);
-        return;
+        return this._isErrorIgnoredOption(data.message);
       }
 
       if (data && !results.some((it) => it.id === data.id)) {
@@ -445,6 +444,21 @@ class Distributor {
    */
   getImportId(hash) {
     return hash.includes('_') ? hash.split('_')[1] : false;
+  }
+
+  /**
+   * Is error ignored option
+   * @param {Error} error 
+   * @return {void}
+   * @private
+   */
+  _isErrorIgnoredOption(error) {
+    if (this.command.getName() === 'run' && this.command.getOption('ignore-missing') === true) {
+      if (error.message.includes('Error: Unable to find remote state')) {
+        return;
+      }
+    }
+    this.errors.push(error);
   }
 
   /**

--- a/src/templates/help/metadata.json
+++ b/src/templates/help/metadata.json
@@ -942,6 +942,12 @@
           "defaultValue": false
         },
         {
+          "name": "ignore-missing",
+          "shortcut": "s",
+          "description": "Ignore missing terraform state(s)",
+          "defaultValue": false
+        },
+        {
           "name": "include",
           "shortcut": "i",
           "description": "List of components to include (comma separated values)",


### PR DESCRIPTION
## Description
Ignore missing terraform remote states in S3

## Type of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a change to the documentation

## How Has This Been Tested?
- [x] terrahub run -s
